### PR TITLE
Ability to turn off strict mode for compiling hb template

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Options:
   -s, --saveOutput    Whether to save the created html output to the same
                       directory as the template, this will override the -o /
                       --outputPath option             [boolean] [default: false]
+  -m, --strictMode    Whether to compile handlebar template in strict mode or not
+                                                      [boolean] [default: true]
 ```
 
 ## Author

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,4 +39,11 @@ export const getCliArgs = (processArgv: any) =>
         type: "boolean",
         default: false,
       },
+      m: {
+        alias: "strictMode",
+        demandOption: false,
+        describe: "Whether to compile handlebar template in strict mode or not",
+        type: "boolean",
+        default: true,
+      }
     }).argv;

--- a/src/render-template.ts
+++ b/src/render-template.ts
@@ -1,12 +1,16 @@
+import { getCliArgs } from "./cli";
+
 const { readFile } = require("fs").promises;
 const hbs = require("handlebars");
+
+const { m: strictMode } = getCliArgs(process.argv);
 
 export async function renderTemplate(data: any, templateName: string) {
   const html = await readFile(templateName, "utf-8");
 
   // creates the Handlebars template object
   const template = hbs.compile(html, {
-    strict: true,
+    strict: strictMode,
   });
 
   // renders the html template with the given data


### PR DESCRIPTION
Turn of strict complie of hb template by
```
handlebars-hot-reload -t <templatePath>  -j <dataPath> -m false
```